### PR TITLE
GPII-2157: Hot-patch console.error in order to suppress pouchdb-express conflict warnings

### DIFF
--- a/src/js/pouchdb-common.js
+++ b/src/js/pouchdb-common.js
@@ -14,6 +14,16 @@ var PouchDB = PouchDB || require("pouchdb");
 
 fluid.registerNamespace("gpii.pouch");
 
+// Hot-patch console.error in order to suppress conflict warnings as described in GPII-2157
+var origConsoleError = console.error;
+
+console.error = function (arg0) {
+    if (arg0 && arg0.constructor.name === "PouchError" && arg0.name === "conflict") {
+        return;
+    }
+    return origConsoleError.apply(console, arguments);
+};
+
 gpii.pouch.init = function (that) {
     that.pouchDb = new PouchDB(that.options.dbOptions);
     fluid.log(fluid.logLevel.TRACE, "Pouch instance `" + that.options.dbOptions.name + "` (" + that.id + ") initialized...");


### PR DESCRIPTION
See https://issues.gpii.net/browse/GPII-2157 and https://botbot.me/freenode/fluid-work/2016-11-21/?msg=76820405&page=2